### PR TITLE
Reset view_method default max_length to 200

### DIFF
--- a/rest_framework_tracking/base_models.py
+++ b/rest_framework_tracking/base_models.py
@@ -32,7 +32,7 @@ class BaseAPIRequestLog(models.Model):
         db_index=True,
     )
     view_method = models.CharField(
-        max_length=getattr(settings, 'DRF_TRACKING_VIEW_METHOD_LENGTH', 27),
+        max_length=getattr(settings, 'DRF_TRACKING_VIEW_METHOD_LENGTH', 200),
         null=True,
         blank=True,
         db_index=True,


### PR DESCRIPTION
We have some `view_method` values that exceed 27 chars so upgrading to latest causes some problems for us. Can the default for this field be `200` like the other varchar fields in these models (and like the field used to be)?