### PR TITLE
Fix broken logging for requests from IPv6 addresses.

### DIFF
--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -50,6 +50,38 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.remote_addr, '127.0.0.9')
 
+    def test_log_ip_remote_v4_with_port(self):
+        request = APIRequestFactory().get('/logging')
+        request.META['REMOTE_ADDR'] = '127.0.0.9:1234'
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, '127.0.0.9')
+
+    def test_log_ip_remote_v6(self):
+        request = APIRequestFactory().get('/logging')
+        request.META['REMOTE_ADDR'] = '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, '2001:db8:85a3::8a2e:370:7334')
+
+    def test_log_ip_remote_v6_loopback(self):
+        request = APIRequestFactory().get('/logging')
+        request.META['REMOTE_ADDR'] = '::1'
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, '::1')
+
+    def test_log_ip_remote_v6_with_port(self):
+        request = APIRequestFactory().get('/logging')
+        request.META['REMOTE_ADDR'] = '[::1]:1234'
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, '::1')
+
     def test_log_ip_xforwarded(self):
         request = APIRequestFactory().get('/logging')
         request.META['HTTP_X_FORWARDED_FOR'] = '127.0.0.8'


### PR DESCRIPTION
https://github.com/lingster/drf-api-tracking/issues/20

Properly parse out port numbers from IPv4 and IPv6 addresses.