### PR TITLE
changed username attribute to get_username() method

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -78,7 +78,7 @@ class BaseLoggingMixin(object):
                     'query_params': self._clean_data(request.query_params.dict()),
                     'user': self._get_user(request),
                     'username_persistent':
-                        self._get_user(request).username if self._get_user(request) else 'Anonymous',
+                        self._get_user(request).get_username() if self._get_user(request) else 'Anonymous',
                     'response_ms': self._get_response_ms(),
                     'response': self._clean_data(rendered_content),
                     'status_code': response.status_code,


### PR DESCRIPTION
This is a minor change to use get_username() method instead of directly accessing username attribute of User model.
reference:
https://docs.djangoproject.com/en/3.1/ref/contrib/auth/

This is something I was facing problem personally and thought many people like me will benefit from this minor change.

Please refer issue #31 for details.