### PR TITLE
added django management command to delete api logs

### DIFF
--- a/rest_framework_tracking/management/commands/clearapilogs.py
+++ b/rest_framework_tracking/management/commands/clearapilogs.py
@@ -1,0 +1,37 @@
+from django.core.management.base import BaseCommand, CommandError
+from rest_framework_tracking.models import APIRequestLog
+from optparse import make_option
+import datetime
+from django.utils import timezone
+
+class Command(BaseCommand):
+    help = 'Removes all api logs OR keeps X number of days of api logs'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days_num',
+            help='Keep X number of days of logs and delete the rest',
+            type=int,
+            choices=[x + 1 for x in range(7)],
+        )
+
+    def handle(self, *args, **options):
+        days_num = options['days_num']
+
+        if days_num:
+            today = timezone.now()
+            start_date = today-datetime.timedelta(days=days_num)
+            logs_to_delete = APIRequestLog.objects.filter(requested_at__lt=start_date)
+
+        else:
+            logs_to_delete = APIRequestLog.objects.all().delete()
+        
+        deleted_logs_count = logs_to_delete.count()
+        logs_to_delete.delete()
+
+        if deleted_logs_count:
+            success_message = f'Successfully removed {deleted_logs_count} api log{"s" if deleted_logs_count > 1 else ""}'
+        else:
+            success_message = 'No logs to delete'
+
+        self.stdout.write(self.style.SUCCESS(success_message))

--- a/rest_framework_tracking/management/commands/clearapilogs.py
+++ b/rest_framework_tracking/management/commands/clearapilogs.py
@@ -12,7 +12,7 @@ class Command(BaseCommand):
             '--days_num',
             help='Keep X number of days of logs and delete the rest',
             type=int,
-            choices=[x + 1 for x in range(7)],
+            choices=[x + 1 for x in range(100000)],
         )
 
     def handle(self, *args, **options):

--- a/rest_framework_tracking/management/commands/clearapilogs.py
+++ b/rest_framework_tracking/management/commands/clearapilogs.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             logs_to_delete = APIRequestLog.objects.filter(requested_at__lt=start_date)
 
         else:
-            logs_to_delete = APIRequestLog.objects.all().delete()
+            logs_to_delete = APIRequestLog.objects.all()
         
         deleted_logs_count = logs_to_delete.count()
         logs_to_delete.delete()


### PR DESCRIPTION
adds functionality requested from issue https://github.com/lingster/drf-api-tracking/issues/9

Now you can either delete all API logs or keep a number of days via a Django management command like this:

**REMOVE ALL API LOGS**
```
python manage.py clearapilogs
```

**ONLY KEEP X NUMBER OF DAYS OF LOGS**
```
python manage.py clearapilogs --days_num 2
```