### PR TITLE
feat: decode_request_body option

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ class LoggingView(LoggingMixin, generics.GenericAPIView):
             super(MockCustomLogHandlerView, self).handle_log()
 ```
 
+If your endpoint accepts large file uploads, drf-api-tracking's default behavior to decode the request body may cause a `RequestDataTooBig` exception. This behavior can be disabled globally by setting `DRF_TRACKING_DECODE_REQUEST_BODY = FALSE` in your `settings.py`file.
+
+You can also customize this behavior for individual views by setting the `decode_request_body` attribute:
+
+``` python
+class LoggingView(LoggingMixin, generics.GenericAPIView):
+    decode_request_body = False
+```
 
 ## Security
 
@@ -162,7 +170,7 @@ By default drf-tracking allows API request log entries to be modified from Djang
 
 ## Development
 In the folder there is a sample drf project: `drf_api_sample` if changes are made to this packages models, use this project
-to help generate new migrations, which should be checked in. 
+to help generate new migrations, which should be checked in.
 
 ## Testing
 
@@ -191,7 +199,7 @@ pyenv install 3.6.11
 pyenv local 3.8.4 3.7.7 3.6.11
 pyenv global 3.8.4 3.7.7 3.6.11
 ```
-Also ensure that you don't have a virtualenv activated when you run the tests else you might get the following error, or similar: 
+Also ensure that you don't have a virtualenv activated when you run the tests else you might get the following error, or similar:
 `
 ERROR: InterpreterNotFound: python3.6
 `
@@ -239,4 +247,3 @@ using pyenv you can install multiple versions of python so that tox can run test
 pyenv global 3.6.8 3.7.7 3.8.2
 ```
 ensure that before running tox you don't have a virtualenv created and tox has been installed globally or via pipx
-

--- a/rest_framework_tracking/admin.py
+++ b/rest_framework_tracking/admin.py
@@ -1,10 +1,12 @@
-from django.conf import settings
+import datetime
+
 from django.contrib import admin
 from django.db.models import Count
 from django.db.models.functions import TruncDay
 from django.urls import path
 from django.http import JsonResponse
-import datetime
+
+from .app_settings import app_settings
 from .models import APIRequestLog
 
 
@@ -19,7 +21,7 @@ class APIRequestLogAdmin(admin.ModelAdmin):
     search_fields = ('path', 'user__email',)
     raw_id_fields = ('user', )
 
-    if getattr(settings, 'DRF_TRACKING_ADMIN_LOG_READONLY', False):
+    if app_settings.ADMIN_LOG_READONLY:
         readonly_fields = ('user', 'username_persistent', 'requested_at',
                            'response_ms', 'path', 'view', 'view_method',
                            'remote_addr', 'host', 'method', 'query_params',
@@ -38,7 +40,7 @@ class APIRequestLogAdmin(admin.ModelAdmin):
 
         # Call the superclass changelist_view to render the page
         return super().changelist_view(request, extra_context=extra_context)
-    
+
     def get_urls(self):
         urls = super().get_urls()
         extra_urls = [

--- a/rest_framework_tracking/app_settings.py
+++ b/rest_framework_tracking/app_settings.py
@@ -1,0 +1,31 @@
+class AppSettings(object):
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def _setting(self, name, dflt):
+        from django.conf import settings
+        return getattr(settings, self.prefix + name, dflt)
+
+    @property
+    def ADMIN_LOG_READONLY(self):
+        """ Prevent log entries from being modified from Django admin. """
+        return self._setting('ADMIN_LOG_READONLY', False)
+
+    @property
+    def DECODE_REQUEST_BODY(self):
+        """
+        Allow the request.body byte string to be decoded to a string.
+
+        If you are allowing large file uploads, setting this to False prevents
+        a RequestDataTooBig exception.
+        """
+        return self._setting('DECODE_REQUEST_BODY', True)
+
+    @property
+    def PATH_LENGTH(self):
+        """ Maximum length of request path to log """
+        return self._setting('PATH_LENGTH', 200)
+
+
+app_settings = AppSettings('DRF_TRACKING_')

--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -5,8 +5,8 @@ import traceback
 
 from django.db import connection
 from django.utils.timezone import now
-from django.conf import settings
 
+from .app_settings import app_settings
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,10 @@ class BaseLoggingMixin(object):
 
     def initial(self, request, *args, **kwargs):
         self.log = {"requested_at": now()}
-        self.log["data"] = self._clean_data(request.body)
+        if not getattr(self, "decode_request_body", app_settings.DECODE_REQUEST_BODY):
+            self.log["data"] = ''
+        else:
+            self.log["data"] = self._clean_data(request.body)
 
         super(BaseLoggingMixin, self).initial(request, *args, **kwargs)
 
@@ -98,7 +101,6 @@ class BaseLoggingMixin(object):
                 # ensure that all exceptions raised by handle_log
                 # doesn't prevent API call to continue as expected
                 logger.exception("Logging API call raise exception!")
-
         return response
 
     def handle_log(self):
@@ -111,9 +113,7 @@ class BaseLoggingMixin(object):
 
     def _get_path(self, request):
         """Get the request path and truncate it"""
-        path_max_length = getattr(settings, 'DRF_TRACKING_PATH_LENGTH', 200)
-
-        return request.path[:path_max_length]
+        return request.path[:app_settings.PATH_LENGTH]
 
     def _get_ip_address(self, request):
         """Get the remote ip address the request was generated from. """
@@ -199,6 +199,7 @@ class BaseLoggingMixin(object):
 
         if isinstance(data, list):
             return [self._clean_data(d) for d in data]
+
         if isinstance(data, dict):
             SENSITIVE_FIELDS = {
                 "api",

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -484,3 +484,9 @@ class TestLoggingMixin(APITestCase):
         self.client.get('/custom-log-handler')
         self.client.post('/custom-log-handler')
         self.assertEqual(APIRequestLog.objects.all().count(), 1)
+
+    @override_settings(DATA_UPLOAD_MAX_MEMORY_SIZE=1)
+    def test_decode_request_body_setting(self):
+        content_type = "multipart/form-data; boundary=_"
+        response = self.client.post('/decode-request-body-false', {"data": "some test data"}, content_type=content_type)
+        self.assertEqual(response.status_code, 200)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -41,5 +41,6 @@ urlpatterns = [
     url(r'^no-view-log$', test_views.MockNameAPIView.as_view()),
     url(r'^view-log$', test_views.MockNameViewSet.as_view({'get': 'list'})),
     url(r'^400-body-parse-error-logging$', test_views.Mock400BodyParseErrorLoggingView.as_view()),
+    url(r'^decode-request-body-false$', test_views.MockDecodeRequestBodyFalse.as_view()),
     url(r'', include(router.urls))
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,16 +1,18 @@
+import time
+
+from rest_framework import mixins, serializers, status, viewsets
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
+from rest_framework.exceptions import APIException
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework_tracking.mixins import LoggingErrorsMixin, LoggingMixin
+from rest_framework_tracking.models import APIRequestLog
+from rest_framework.views import APIView
+from tests.test_serializers import ApiRequestLogSerializer, UserSerializer
+
 from django.contrib.auth.models import User
 from django.http.response import StreamingHttpResponse
 from django.shortcuts import get_list_or_404
-from rest_framework.authentication import SessionAuthentication, TokenAuthentication
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework import serializers, viewsets, mixins
-from rest_framework.exceptions import APIException
-from rest_framework_tracking.mixins import LoggingErrorsMixin, LoggingMixin
-from rest_framework_tracking.models import APIRequestLog
-from tests.test_serializers import ApiRequestLogSerializer, UserSerializer
-import time
 
 
 class MockNoLoggingView(APIView):
@@ -234,3 +236,10 @@ class MockCustomLogHandlerView(LoggingMixin, APIView):
     def post(self, request):
         time.sleep(1)
         return Response('Slow request. Save it on db.')
+
+
+class MockDecodeRequestBodyFalse(LoggingMixin, APIView):
+    decode_request_body = False
+
+    def post(self, request):
+        return Response({"decode_request_body": False}, status=status.HTTP_200_OK)


### PR DESCRIPTION
I've added the a decode_request_body option to resolve #47.  It's configurable both globally and on a per-view basis. ReadMe and tests updated as well.

I've also added `app_settings.py` and populated it with all of the settings available so far, and adjusted their corresponding code to not call `getattr()` when referencing those settings.  This should make adding any future settings easier.





