### PR TITLE
Parse REMOTE_ADDR list and return first element in _get_ip_address

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -119,7 +119,7 @@ class BaseLoggingMixin(object):
         if ipaddr:
             ipaddr = ipaddr.split(",")[0]
         else:
-            ipaddr = request.META.get("REMOTE_ADDR", "")
+            ipaddr = request.META.get("REMOTE_ADDR", "").split(",")[0]
 
         # Account for IPv4 and IPv6 addresses, each possibly with port appended. Possibilities are:
         # <ipv4 address>

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -50,6 +50,14 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.remote_addr, '127.0.0.9')
 
+    def test_log_ip_remote_list(self):
+        request = APIRequestFactory().get('/logging')
+        request.META['REMOTE_ADDR'] = '127.0.0.9, 128.1.1.9'
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, '127.0.0.9')
+
     def test_log_ip_remote_v4_with_port(self):
         request = APIRequestFactory().get('/logging')
         request.META['REMOTE_ADDR'] = '127.0.0.9:1234'


### PR DESCRIPTION
Request headers from some services, e.g. Google Cloud, include a list of IP addresses in the REMOTE_ADDR field. When the log information is saved to the logging table an error occurs as the format of the IP field does not match type inet in the database table. This causes an error and the information is not saved. 
I've added a .split(",")[0] to return the first IP address if a list is given. I've also added a test to test this functionality.