### PR TITLE
Support for custom user lookup fields added

### DIFF
--- a/rest_framework_tracking/admin.py
+++ b/rest_framework_tracking/admin.py
@@ -28,7 +28,7 @@ class APIRequestLogAdmin(admin.ModelAdmin):
     list_filter = ("view_method", "status_code")
     search_fields = (
         "path",
-        "user__email",
+        f"user__{app_settings.LOOKUP_FIELD}",
     )
     raw_id_fields = ("user",)
 

--- a/rest_framework_tracking/app_settings.py
+++ b/rest_framework_tracking/app_settings.py
@@ -27,5 +27,10 @@ class AppSettings(object):
         """Maximum length of request path to log"""
         return self._setting("PATH_LENGTH", 200)
 
+    @property
+    def LOOKUP_FIELD(self):
+        """Field to identify user in User model"""
+        return self._setting("LOOKUP_FIELD", 'email')
+
 
 app_settings = AppSettings("DRF_TRACKING_")


### PR DESCRIPTION
Some people use other names for the field 'email' in the User model, this way we allow them to still user drf-api-tracking without getting an error when searching from the admin panel. The name of the parameter is taken from django rest framework.