### PR TITLE
Conditionally define default_app_config

### DIFF
--- a/rest_framework_tracking/__init__.py
+++ b/rest_framework_tracking/__init__.py
@@ -1,2 +1,5 @@
 __version__ = "1.8.0"
-default_app_config = "rest_framework_tracking.apps.RestFrameworkTrackingConfig"
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = "rest_framework_tracking.apps.RestFrameworkTrackingConfig"


### PR DESCRIPTION
Addressing issue: https://github.com/lingster/drf-api-tracking/issues/89

This conditionally defines `default_app_config` for Django versions < 3.2 so that the library will support Django 4.1.