### PR TITLE
chore: Explicitly set default auto field

### DIFF
--- a/rest_framework_tracking/apps.py
+++ b/rest_framework_tracking/apps.py
@@ -2,5 +2,7 @@ from django.apps import AppConfig
 
 
 class RestFrameworkTrackingConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
+
     name = "rest_framework_tracking"
     verbose_name = "REST Framework Tracking"


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

Users may set `DEFAULT_AUTO_FIELD` to `django.db.models.BigAutoField` in settings.
In that case, it will create an additional migration file which updates `APIRequestLog` table id to `BigAutoField`.
And it's causing problem during the migration in each deployment and testing with `tox`.

If we explicitly set `default_auto_field` in app config, we can avoid unexpected migration.