### PR TITLE
Fix edge cases with unknown IP address

### DIFF
--- a/rest_framework_tracking/base_mixins.py
+++ b/rest_framework_tracking/base_mixins.py
@@ -120,14 +120,18 @@ class BaseLoggingMixin(object):
         # <ipv4 address>:port
         # [<ipv6 address>]:port
         # Note that ipv6 addresses are colon separated hex numbers
-        possibles = [
-            i.strip()
-            for sublist in [
-                (ipaddr.lstrip("[").split("]")[0], ipaddr.split(":")[0])
-                for ipaddr in raw_possibles
-            ]
-            for i in sublist
-        ]
+        raw_possibles = [addr.strip() for addr in raw_possibles]
+        possibles = []
+        for possible_addr in raw_possibles:
+            if '[' in possible_addr:
+                # IPv6 with port
+                possibles.append(possible_addr.rsplit(":", 1)[0].strip("[]"))
+            elif possible_addr.count(":") == 1:
+                # IPv4 with port
+                possibles.append(possible_addr.split(":")[0])
+            else:
+                # IPv4/IPv6 without port and others
+                possibles.append(possible_addr)
         for addr in possibles:
             try:
                 return str(ipaddress.ip_address(addr))

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -105,6 +105,14 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.remote_addr, "127.0.0.8")
 
+    def test_log_ip_xforwarded_list_with_unkown_ip(self):
+        request = APIRequestFactory().get("/logging")
+        request.META["HTTP_X_FORWARDED_FOR"] = "unknown, 128.1.1.9"
+
+        MockLoggingView.as_view()(request).render()
+        log = APIRequestLog.objects.first()
+        self.assertEqual(log.remote_addr, "128.1.1.9")
+
     def test_log_host(self):
         self.client.get("/logging")
         log = APIRequestLog.objects.first()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -105,7 +105,7 @@ class TestLoggingMixin(APITestCase):
         log = APIRequestLog.objects.first()
         self.assertEqual(log.remote_addr, "127.0.0.8")
 
-    def test_log_ip_xforwarded_list_with_unkown_ip(self):
+    def test_log_ip_xforwarded_list_with_unknown_ip(self):
         request = APIRequestFactory().get("/logging")
         request.META["HTTP_X_FORWARDED_FOR"] = "unknown, 128.1.1.9"
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ tox_pyenv_fallback = True
 commands = python -V
            pip install --upgrade pip pipenv
            pipenv install --skip-lock
-           ./runtests.py --fast
+           python runtests.py --fast
 passenv =
     DATABASE_URL
     PYTHON_VERSION


### PR DESCRIPTION
For some reason, `HTTP_X_FORWARDED_FOR` might be set as `"unknown, 128.1.1.9"`, we should be able to parse and use the closest valid value.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses an edge case in IP address parsing where the `HTTP_X_FORWARDED_FOR` header might contain 'unknown'. The code now correctly parses and uses the closest valid IP address. Additionally, a test has been added to ensure this functionality works as expected.

- **Bug Fixes**:
    - Fixed edge case where `HTTP_X_FORWARDED_FOR` header contains 'unknown' by parsing and using the closest valid IP address.
- **Tests**:
    - Added test to verify correct IP address is logged when `HTTP_X_FORWARDED_FOR` contains 'unknown'.

<!-- Generated by sourcery-ai[bot]: end summary -->